### PR TITLE
Docker image for standalone GPU Caffe

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,53 @@
+## Standalone Dockerfiles
+
+The `standalone` subfolder contains a docker file to correctly install GPU executable image for [deeplab-public-ver2](https://bitbucket.org/aquariusjay/deeplab-public-ver2).
+The image can be built by running:
+
+```
+nvidia-docker build -t caffe_dl:gpu standalone/dl_gpu
+```
+
+The image requires a CUDA 7.5 capable driver to be installed on the system and [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) for running the Docker containers.
+
+For more information on how to run Caffe using the docker image please refer to the [Caffe guide](https://github.com/BVLC/caffe/blob/master/docker/README.md).
+
+# Running Caffe using the docker image
+
+In order to test the Caffe image, run:
+```
+nvidia-docker run -ti caffe_dl:gpu caffe --version
+```
+which should show a message like:
+```
+libdc1394 error: Failed to initialize libdc1394
+caffe version 1.0.0-rc3
+```
+
+One can also build and run the Caffe tests in the image using:
+```
+nvidia-docker run -ti caffe_dl:gpu bash -c "cd /opt/caffe/build; make runtest"
+```
+
+In order to get the most out of the caffe image, some more advanced `docker run` options could be used. For example, running:
+```
+nvidia-docker run -ti --volume=$(pwd):/workspace caffe_dl:gpu caffe train --solver=example_solver.prototxt
+```
+will train a network defined in the `example_solver.prototxt` file in the current directory (`$(pwd)` is maped to the container volume `/workspace` using the `--volume=` Docker flag).
+
+Note that docker runs all commands as root by default, and thus any output files (e.g. snapshots) generated will be owned by the root user. In order to ensure that the current user is used instead, the following command can be used:
+```
+nvidia-docker run -ti --volume=$(pwd):/workspace -u $(id -u):$(id -g) caffe_dl:gpu caffe train --solver=example_solver.prototxt
+```
+where the `-u` Docker command line option runs the commands in the container as the specified user, and the shell command `id` is used to determine the user and group ID of the current user. Note that the Caffe docker images have `/workspace` defined as the default working directory. This can be overridden using the `--workdir=` Docker command line option.
+
+# Other use-cases
+
+Although running the `caffe` command in the docker containers as described above serves many purposes, the container can also be used for more interactive use cases. For example, specifying `bash` as the command instead of `caffe` yields a shell that can be used for interactive tasks. (Since the caffe build requirements are included in the container, this can also be used to build and run local versions of caffe).
+
+Another use case is to run python scripts that depend on `caffe`'s Python modules. Using the `python` command instead of `bash` or `caffe` will allow this, and an interactive interpreter can be started by running:
+```
+nvidia-docker run -ti caffe_dl:gpu python
+```
+(`ipython` is also available in the container).
+
+Since the `caffe/python` folder is also added to the path, the utility executable scripts defined there can also be used as executables. This includes `draw_net.py`, `classify.py`, and `detect.py`

--- a/docker/standalone/dl_gpu/Dockerfile
+++ b/docker/standalone/dl_gpu/Dockerfile
@@ -1,0 +1,57 @@
+FROM nvidia/cuda:7.5-cudnn4-devel-ubuntu14.04
+MAINTAINER caffe-maint@googlegroups.com
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        wget \
+        libatlas-base-dev \
+        libboost-all-dev \
+        libgflags-dev \
+        libgoogle-glog-dev \
+        libhdf5-serial-dev \
+        libleveldb-dev \
+        liblmdb-dev \
+        libopencv-dev \
+        libprotobuf-dev \
+        libsnappy-dev \
+        protobuf-compiler \
+        python-dev \
+        python-numpy \
+        python-pip \
+        python-scipy && \
+    rm -rf /var/lib/apt/lists/*
+    
+WORKDIR /opt
+
+# MATIO
+RUN wget http://jaist.dl.sourceforge.net/project/matio/matio/1.5.2/matio-1.5.2.tar.gz && \
+    tar -xvzf matio-1.5.2.tar.gz && \
+    rm matio-1.5.2.tar.gz
+    
+WORKDIR /opt/matio-1.5.2
+
+RUN ./configure && make -j8 && make install -j8
+
+ENV CAFFE_ROOT=/opt/caffe
+WORKDIR $CAFFE_ROOT
+
+ENV INCLUDE_DIRS=/opt/matio-1.5.2/src/:$INCLUDE_DIRS
+ENV LIBRARY_DIRS=/opt/matio-1.5.2/src/:$LIBRARY_DIRS
+
+# FIXME: clone a specific git tag and use ARG instead of ENV once DockerHub supports this.
+ENV CLONE_TAG=master
+
+RUN git clone -b ${CLONE_TAG} --depth 1 https://bitbucket.org/aquariusjay/deeplab-public-ver2.git . && \
+    for req in $(cat python/requirements.txt) pydot; do pip install $req; done && \
+    cp Makefile.config.example Makefile.config && \
+    make all -j8 && \
+    make pycaffe -j8
+
+ENV PYCAFFE_ROOT $CAFFE_ROOT/python
+ENV PYTHONPATH $PYCAFFE_ROOT:$PYTHONPATH
+ENV PATH $CAFFE_ROOT/build/tools:$PYCAFFE_ROOT:$PATH
+RUN echo "$CAFFE_ROOT/build/lib" >> /etc/ld.so.conf.d/caffe.conf && ldconfig
+
+WORKDIR /workspace


### PR DESCRIPTION
This contains a standalone dockerfile to correctly install GPU executable image for deeplab-public-ver2 (with matio installed as well). 